### PR TITLE
Implement safe_to_numeric function to handle FutureWarning in dataframe conversions

### DIFF
--- a/pybroom.py
+++ b/pybroom.py
@@ -290,6 +290,13 @@ def _multi_dataframe(func, results, var_names, **kwargs):
         df = df.assign(**kw)
     return df
 
+# Avoid the FutureWarning by catching exceptions explicitly
+def safe_to_numeric(series):
+    try:
+        return pd.to_numeric(series)
+    except ValueError:
+        return series
+
 
 def tidy_lmfit_result(result):
     """Tidy parameters from lmfit's  `ModelResult` or `MinimizerResult`.
@@ -325,7 +332,7 @@ def tidy_lmfit_result(result):
         # Derived parameters may not have init value
         if name in result.init_values:
             d.loc[i, 'init_value'] = result.init_values[name]
-    return d.apply(pd.to_numeric, errors='ignore')
+    return d.apply(safe_to_numeric)
 
 
 def tidy_scipy_result(result, param_names, **kwargs):
@@ -399,7 +406,7 @@ def glance_scipy_result(result):
     d = pd.DataFrame(index=range(1), columns=attr_names)
     for attr_name in attr_names:
         d.loc[0, attr_name] = getattr(result, attr_name)
-    return d.apply(pd.to_numeric, errors='ignore')
+    return d.apply(safe_to_numeric)
 
 
 def glance_lmfit_result(result):
@@ -455,7 +462,7 @@ def glance_lmfit_result(result):
     if hasattr(result, 'kws') and result.kws is not None:
         for key, value in result.kws.items():
             d['_'.join((result.method, key))] = value
-    return d.apply(pd.to_numeric, errors='ignore')
+    return d.apply(safe_to_numeric)
 
 
 def _augment_lmfit_modelresult(result):
@@ -481,7 +488,7 @@ def _augment_lmfit_modelresult(result):
         comp_names = [c.name for c in result.components]
         for cname, comp in zip(comp_names, result.components):
             d.loc[:, cname] = comp.eval(x=d.x, **result.values)
-    return d.apply(pd.to_numeric, errors='ignore')
+    return d.apply(safe_to_numeric)
 
 
 def tidy_to_dict(df, key='name', value='value', keys_exclude=None,


### PR DESCRIPTION
Thank you for this, is a very useful tool to manage the LMFIT results.
With recent pandas version a futurewarning appeared 

Proposing to merge this to avoid the:

```
pybroom.py:328: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead
  return d.apply(pd.to_numeric, errors='ignore')
```
to capture the exception explicitly I added the safe_to_numeric function:

```python
def safe_to_numeric(series):
    try:
        return pd.to_numeric(series)
    except ValueError:
        return series
```

there may be a more elegant way but this seems to work for me even if I'm not sure if I tested all cases.
thanks
    Marco

